### PR TITLE
Refine Chapter 3 study presentation

### DIFF
--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/deck.css
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/deck.css
@@ -1426,6 +1426,25 @@ body.chrome-hidden .deck-settings {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.audit-grid--six {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.audit-grid--six article {
+  padding: 12px 14px;
+}
+
+.audit-grid--six h2 {
+  margin: 5px 0 4px;
+  font-size: 17px;
+}
+
+.audit-grid--six p {
+  font-size: 12.5px;
+  line-height: 1.32;
+}
+
 .fact-grid article,
 .audit-grid article,
 .gate-grid article,
@@ -1497,8 +1516,52 @@ body.chrome-hidden .deck-settings {
 .query-strip pre {
   margin: 0;
   min-height: 282px;
-  font-size: 13px;
-  line-height: 1.42;
+  padding: 14px 16px;
+  overflow: hidden;
+  color: #eef4ff;
+  background: #0d1624;
+  border: 1px solid #26364f;
+  border-radius: 14px;
+  font-size: 12.5px;
+  line-height: 1.23;
+}
+
+.fact-grid--safety article {
+  min-height: 136px;
+}
+
+.safety-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 22px;
+  padding: 19px 22px;
+  color: #fff;
+  background: var(--primary-deep);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+}
+
+.safety-flow span,
+.safety-flow strong,
+.safety-flow em {
+  font-size: 17px;
+  font-style: normal;
+  font-weight: 850;
+}
+
+.safety-flow b {
+  color: #a9c9f6;
+  font-size: 22px;
+}
+
+.safety-flow em {
+  margin-left: 10px;
+  padding: 7px 11px;
+  color: var(--primary-deep);
+  background: #fff;
+  border-radius: 999px;
 }
 
 .ranking-list {
@@ -1537,6 +1600,16 @@ body.chrome-hidden .deck-settings {
 .ranking-list p,
 .ranking-list small {
   margin: 0;
+}
+
+.ranking-list .tie-list small {
+  display: block;
+  font-size: 11px;
+  line-height: 1.32;
+}
+
+.ranking-list .tie-list small + small {
+  margin-top: 3px;
 }
 
 .ranking-list p {

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/annotation-lifecycle.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/annotation-lifecycle.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 285" role="img" aria-labelledby="title desc">
   <title id="title">HPOA 한 행이 추적 가능한 그래프 관계가 되는 생애주기</title>
   <desc id="desc">TSV 한 행에서 질병과 표현형 ID를 매칭하고 관계를 생성한 뒤 원시 근거 필드를 추가하고 사람이 읽는 설명과 URL로 풍부화하며 품질 점검을 거친다.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0 10 5 0 10Z" fill="#63728a"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#53647d}
@@ -12,7 +12,7 @@
       .line{fill:none;stroke:#63728a;stroke-width:3;marker-end:url(#arrow)}
     </style>
   </defs>
-  <rect width="960" height="420" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="285" rx="20" fill="#f7f8fa"/>
   <text x="480" y="42" class="eyebrow" text-anchor="middle">ONE HPOA ROW → ONE AUDITABLE ASSERTION</text>
   <g>
     <rect class="box" x="35" y="78" width="166" height="175" rx="15"/>
@@ -51,8 +51,5 @@
     <text x="811" y="197" class="small">날짜 파싱?</text>
     <text x="811" y="219" class="small">건수 보존?</text>
   </g>
-  <path class="line" d="M201 165H216"/><path class="line" d="M390 165H405"/><path class="line" d="M579 165H594"/><path class="line" d="M768 165H783"/>
-  <rect x="87" y="301" width="786" height="72" rx="14" fill="#e3ebf5" stroke="#8fa3bf"/>
-  <text x="480" y="329" class="head" text-anchor="middle">중요한 구현 경계</text>
-  <text x="480" y="355" class="small" text-anchor="middle">같은 질병–표현형 쌍의 주석이 여러 건이면 관계 식별자 없이 MERGE한 한 엣지에 마지막 값이 덮어써질 수 있다.</text>
+  <path class="line" d="M201 165H224"/><path class="line" d="M390 165H413"/><path class="line" d="M579 165H602"/><path class="line" d="M768 165H791"/>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/build-pipeline.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/build-pipeline.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 500" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 475" role="img" aria-labelledby="title desc">
   <title id="title">임상 질문에서 HPO 기반 지식 그래프와 검증된 질의까지 이어지는 구축 파이프라인</title>
   <desc id="desc">비즈니스 질문, 두 데이터 원천 이해, 기술 선택, 제약과 온톨로지 적재, 주석 병합과 관계 풍부화, 정제, 직접 질의와 계층 추론의 일곱 단계가 이어지며 각 전환에 검증 게이트가 있다.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0 10 5 0 10Z" fill="#63728a"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.3px;fill:#52647d}
@@ -11,10 +11,9 @@
       .box{fill:#fff;stroke:#b6c2d1;stroke-width:2}
       .navy{fill:#0f2c59;stroke:#0f2c59}
       .line{fill:none;stroke:#63728a;stroke-width:3;marker-end:url(#arrow)}
-      .gate{fill:#e3ebf5;stroke:#8aa0bd}
     </style>
   </defs>
-  <rect width="960" height="500" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="475" rx="20" fill="#f7f8fa"/>
   <text x="55" y="44" class="eyebrow">CRISP-DM을 KG 구축 질문으로 구체화</text>
 
   <g>
@@ -30,13 +29,11 @@
     <text x="738" y="107" class="eyebrow">03 · DESIGN</text>
     <text x="738" y="135" class="head">RDF/LPG 선택</text>
     <text x="738" y="157" class="small">관계 메타데이터 우선</text>
-    <path class="line" d="M244 122H374"/>
-    <path class="line" d="M578 122H708"/>
-    <rect class="gate" x="284" y="103" width="54" height="37" rx="18"/><text x="311" y="127" class="small" text-anchor="middle">질문</text>
-    <rect class="gate" x="618" y="103" width="54" height="37" rx="18"/><text x="645" y="127" class="small" text-anchor="middle">요구</text>
+    <path class="line" d="M244 122H382"/>
+    <path class="line" d="M578 122H716"/>
   </g>
 
-  <path class="line" d="M814 168V218H769"/>
+  <path class="line" d="M814 168V196H766V222"/>
 
   <g>
     <rect class="navy" x="620" y="222" width="292" height="96" rx="14"/>
@@ -51,13 +48,12 @@
     <text x="70" y="252" class="eyebrow">06 · CLEAN &amp; CHECK</text>
     <text x="70" y="282" class="head">불필요 노드 정리</text>
     <text x="70" y="305" class="small">ID·건수·출처·결측 검증</text>
-    <path class="line" d="M620 270H580"/>
-    <path class="line" d="M334 270H294"/>
+    <path class="line" d="M620 270H572"/>
+    <path class="line" d="M334 270H286"/>
   </g>
 
-  <path class="line" d="M167 318V372"/>
+  <path class="line" d="M167 318V375"/>
   <rect class="navy" x="164" y="375" width="632" height="83" rx="16"/>
   <text x="480" y="407" class="eyebrow" text-anchor="middle" style="fill:#c8d6e8">07 · USE</text>
   <text x="480" y="435" class="head" text-anchor="middle" style="fill:#fff">직접 연결 질의 + 표현형 조합 랭킹 + subClassOf 계층 추론</text>
-  <text x="480" y="484" class="small" text-anchor="middle">각 게이트의 산출물: 대표 질문, 원천 계약, 모델 선택 근거, 적재 로그, 품질 점검, 재현 가능한 질의</text>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/clinical-query.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/clinical-query.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 470" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 405" role="img" aria-labelledby="title desc">
   <title id="title">관찰한 다섯 표현형으로 희귀질환 후보를 순위화하는 그래프 질의</title>
   <desc id="desc">제1형 당뇨병, 성장 지연, 큰 무릎, 감각신경성 청각 장애, 소양증 다섯 표현형이 공유 연결 수를 기준으로 질병 후보 세 개에 연결되며 5개, 3개, 2개 순으로 정렬된다.</desc>
   <defs>
@@ -6,6 +6,7 @@
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#52647d}
       .head{font-size:18px;font-weight:800}
+      .candidate-head{font-size:16px;font-weight:800}
       .small{font-size:13px;fill:#56657a}
       .feature{fill:#fff;stroke:#8294ad;stroke-width:2}
       .candidate{fill:#e4ebf5;stroke:#0f2c59;stroke-width:2}
@@ -14,9 +15,9 @@
       .strong{stroke:#0f2c59;stroke-width:3}
     </style>
   </defs>
-  <rect width="960" height="470" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="405" rx="20" fill="#f7f8fa"/>
   <text x="53" y="44" class="eyebrow">OBSERVED PHENOTYPIC FEATURES</text>
-  <text x="681" y="44" class="eyebrow">CANDIDATE DISEASES · OVERLAP COUNT</text>
+  <text x="912" y="44" class="eyebrow" text-anchor="end">CANDIDATE DISEASES · OVERLAP COUNT</text>
 
   <g>
     <rect class="feature" x="48" y="70" width="250" height="48" rx="24"/><text x="173" y="100" class="small" text-anchor="middle">Type I diabetes mellitus</text>
@@ -37,12 +38,11 @@
   <g>
     <rect class="top" x="653" y="79" width="260" height="112" rx="16"/>
     <text x="677" y="109" class="eyebrow" style="fill:#c8d6e8">5 / 5 · TOP IN BOOK SNAPSHOT</text>
-    <text x="677" y="139" class="head" style="fill:#fff">Odontochondrodysplasia 2</text>
+    <text x="677" y="139" class="candidate-head" style="fill:#fff">Odontochondrodysplasia 2</text>
     <text x="677" y="163" class="small" style="fill:#dce6f2">with hearing loss and diabetes</text>
     <rect class="candidate" x="653" y="205" width="260" height="70" rx="15"/>
     <text x="677" y="234" class="eyebrow">3 / 5</text><text x="677" y="259" class="small">Holoprosencephaly 12 …</text>
     <rect class="candidate" x="653" y="310" width="260" height="70" rx="15"/>
     <text x="677" y="339" class="eyebrow">2 / 5</text><text x="677" y="364" class="small">여러 후보가 동률</text>
   </g>
-  <text x="480" y="427" class="small" text-anchor="middle">이 결과는 HPO 2025-02 스냅샷의 겹치는 특징 수 예시다. 후보 생성이지 임상 진단 확정이나 확률 추정이 아니다.</text>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/edge-metadata-options.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/edge-metadata-options.svg
@@ -1,7 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 480" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 425" role="img" aria-labelledby="title desc">
   <title id="title">질병과 표현형 사이 주석 메타데이터를 표현하는 네 가지 방법</title>
   <desc id="desc">RDF n항 관계는 주석 노드를 추가하고, 명명 그래프는 문장 묶음에 이름을 붙이며, RDF-star는 인용한 트리플에 메타데이터를 붙이고, LPG는 개별 관계에 속성을 직접 둔다.</desc>
   <defs>
+    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#0f2c59"/></marker>
+    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#fff"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.3px;fill:#52647d}
@@ -10,38 +12,39 @@
       .small{font-size:13px;fill:#56657a}
       .card{fill:#fff;stroke:#b8c3d2;stroke-width:2}
       .node{fill:#e7eef7;stroke:#0f2c59;stroke-width:2}
-      .edge{stroke:#0f2c59;stroke-width:3}
+      .edge{fill:none;stroke:#0f2c59;stroke-width:3;marker-end:url(#arrow-navy)}
+      .white-edge{fill:none;stroke:#fff;stroke-width:5;marker-end:url(#arrow-white)}
+      .edge-label{paint-order:stroke;stroke:#fff;stroke-width:4px;stroke-linejoin:round}
       .meta{fill:#0f2c59}
     </style>
   </defs>
-  <rect width="960" height="480" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="425" rx="20" fill="#f7f8fa"/>
   <text x="480" y="43" class="eyebrow" text-anchor="middle">ONE ASSERTION · SOURCE + CURATOR + DATE</text>
 
   <g transform="translate(35 68)">
-    <rect class="card" width="425" height="175" rx="16"/>
+    <rect class="card" width="425" height="150" rx="16"/>
     <text x="22" y="32" class="eyebrow">RDF</text><text x="22" y="61" class="head">N-ARY RELATION</text>
     <circle class="node" cx="70" cy="114" r="29"/><text x="70" y="119" class="small" text-anchor="middle">Disease</text>
     <circle class="meta" cx="212" cy="114" r="36"/><text x="212" y="110" class="small" text-anchor="middle" style="fill:#fff">Annotation</text><text x="212" y="128" class="small" text-anchor="middle" style="fill:#fff">resource</text>
     <circle class="node" cx="354" cy="114" r="29"/><text x="354" y="119" class="small" text-anchor="middle">Feature</text>
-    <path class="edge" d="M99 114H176M248 114H325"/>
-    <text x="212" y="164" class="small" text-anchor="middle">메타데이터를 담을 새 개념</text>
+    <path class="edge" d="M176 114H99"/><path class="edge" d="M248 114H325"/>
   </g>
 
   <g transform="translate(500 68)">
-    <rect class="card" width="425" height="175" rx="16"/>
+    <rect class="card" width="425" height="150" rx="16"/>
     <text x="22" y="32" class="eyebrow">RDF</text><text x="22" y="61" class="head">NAMED GRAPH</text>
     <rect x="49" y="79" width="240" height="63" rx="12" fill="#e7eef7" stroke="#0f2c59" stroke-width="2"/>
     <circle class="node" cx="93" cy="110" r="22"/><circle class="node" cx="245" cy="110" r="22"/>
     <path class="edge" d="M115 110H223"/>
-    <text x="169" y="103" class="small" text-anchor="middle">hasFeature</text>
-    <rect class="meta" x="309" y="79" width="86" height="63" rx="12"/>
-    <text x="352" y="105" class="small" text-anchor="middle" style="fill:#fff">Graph1</text>
-    <text x="352" y="126" class="small" text-anchor="middle" style="fill:#fff">metadata</text>
-    <text x="212" y="164" class="small" text-anchor="middle">문장 묶음에 이름과 맥락 부여</text>
+    <text x="169" y="103" class="small edge-label" text-anchor="middle">hasFeature</text>
+    <rect class="meta" x="315" y="79" width="86" height="63" rx="12"/>
+    <text x="358" y="105" class="small" text-anchor="middle" style="fill:#fff">Graph1</text>
+    <text x="358" y="126" class="small" text-anchor="middle" style="fill:#fff">metadata</text>
+    <path class="edge" d="M315 110H289"/>
   </g>
 
-  <g transform="translate(35 275)">
-    <rect class="card" width="425" height="175" rx="16"/>
+  <g transform="translate(35 245)">
+    <rect class="card" width="425" height="150" rx="16"/>
     <text x="22" y="32" class="eyebrow">RDF</text><text x="22" y="61" class="head">RDF-STAR</text>
     <rect x="48" y="83" width="223" height="56" rx="12" fill="#e7eef7" stroke="#0f2c59" stroke-width="2"/>
     <text x="159" y="107" class="label" text-anchor="middle">&lt;&lt; D hasFeature F &gt;&gt;</text>
@@ -50,18 +53,16 @@
     <rect class="meta" x="307" y="83" width="89" height="56" rx="12"/>
     <text x="351" y="106" class="small" text-anchor="middle" style="fill:#fff">source</text>
     <text x="351" y="126" class="small" text-anchor="middle" style="fill:#fff">date</text>
-    <text x="212" y="164" class="small" text-anchor="middle">트리플 자체에 대한 메타데이터</text>
   </g>
 
-  <g transform="translate(500 275)">
-    <rect width="425" height="175" rx="16" fill="#0f2c59"/>
+  <g transform="translate(500 245)">
+    <rect width="425" height="150" rx="16" fill="#0f2c59"/>
     <text x="22" y="32" class="eyebrow" style="fill:#c8d6e8">LPG · CHAPTER CHOICE</text><text x="22" y="61" class="head" style="fill:#fff">RELATIONSHIP PROPERTIES</text>
     <circle cx="77" cy="111" r="28" fill="#fff"/><text x="77" y="116" class="small" text-anchor="middle">Disease</text>
     <circle cx="348" cy="111" r="28" fill="#dfe9f6"/><text x="348" y="116" class="small" text-anchor="middle">Feature</text>
-    <path d="M105 111H320" stroke="#fff" stroke-width="5"/>
+    <path class="white-edge" d="M105 111H320"/>
     <rect x="149" y="80" width="127" height="63" rx="10" fill="#fff"/>
     <text x="212" y="103" class="small" text-anchor="middle">source · evidence</text>
     <text x="212" y="123" class="small" text-anchor="middle">curator · date</text>
-    <text x="212" y="164" class="small" text-anchor="middle" style="fill:#dce6f2">개별 관계에 키–값을 직접 저장</text>
   </g>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/hierarchical-inference.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/hierarchical-inference.svg
@@ -1,8 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 470" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 435" role="img" aria-labelledby="title desc">
   <title id="title">온톨로지 계층이 직접 연결을 상위 범주 질의 결과로 확장하는 과정</title>
-  <desc id="desc">내분비계 이상 상위 개념 아래에 갑상선, 췌장, 포도당 대사 이상 하위 개념이 있고, 질병은 이 하위 표현형에 직접 연결되어 있지만 상위 범주 질의에서는 추론으로 포함된다.</desc>
+  <desc id="desc">HPO의 자식 표현형 세 개가 SUBCLASSOF 관계로 내분비계 이상 상위 개념을 가리킨다. 질병은 하위 표현형에 직접 주석되어 있고 상위 범주 질의에서는 계층 경로를 역방향으로 탐색해 포함된다.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0 10 5 0 10Z" fill="#63728a"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
+    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#0f2c59"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#52647d}
@@ -11,33 +12,34 @@
       .node{fill:#fff;stroke:#8294ad;stroke-width:2}
       .parent{fill:#0f2c59;stroke:#0f2c59}
       .disease{fill:#e3ebf5;stroke:#0f2c59;stroke-width:2}
-      .tree{fill:none;stroke:#7b8ba3;stroke-width:3;marker-end:url(#arrow)}
-      .direct{fill:none;stroke:#0f2c59;stroke-width:4;marker-end:url(#arrow)}
-      .infer{fill:none;stroke:#0f2c59;stroke-width:3;stroke-dasharray:8 6;marker-end:url(#arrow)}
+      .tree{fill:none;stroke:#7b8ba3;stroke-width:3;marker-end:url(#arrow-gray)}
+      .direct{fill:none;stroke:#0f2c59;stroke-width:4;marker-end:url(#arrow-navy)}
+      .infer{fill:none;stroke:#0f2c59;stroke-width:3;stroke-dasharray:8 6;marker-end:url(#arrow-navy)}
     </style>
   </defs>
-  <rect width="960" height="470" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="435" rx="20" fill="#f7f8fa"/>
   <text x="52" y="43" class="eyebrow">ONTOLOGY HIERARCHY</text>
   <text x="708" y="43" class="eyebrow">QUERY RESULT</text>
-  <rect class="parent" x="307" y="68" width="300" height="72" rx="16"/>
-  <text x="457" y="98" class="head" text-anchor="middle" style="fill:#fff">Abnormality of endocrine system</text>
-  <text x="457" y="122" class="small" text-anchor="middle" style="fill:#dce6f2">HP:0000818 · 상위 범주</text>
+  <rect class="parent" x="307" y="60" width="300" height="88" rx="16"/>
+  <text x="457" y="86" class="head" text-anchor="middle" style="fill:#fff">Abnormality of the</text>
+  <text x="457" y="108" class="head" text-anchor="middle" style="fill:#fff">endocrine system</text>
+  <text x="457" y="133" class="small" text-anchor="middle" style="fill:#dce6f2">HP:0000818 · 상위 범주</text>
 
-  <path class="tree" d="M457 140V181H194V217"/><path class="tree" d="M457 181V217"/><path class="tree" d="M457 181H720V217"/>
-  <rect class="node" x="78" y="220" width="232" height="69" rx="14"/>
-  <text x="194" y="248" class="head" text-anchor="middle">Thyroid abnormality</text><text x="194" y="272" class="small" text-anchor="middle">subClassOf</text>
-  <rect class="node" x="341" y="220" width="232" height="69" rx="14"/>
-  <text x="457" y="248" class="head" text-anchor="middle">Pancreas abnormality</text><text x="457" y="272" class="small" text-anchor="middle">subClassOf</text>
-  <rect class="node" x="604" y="220" width="232" height="69" rx="14"/>
-  <text x="720" y="248" class="head" text-anchor="middle">Glucose metabolism</text><text x="720" y="272" class="small" text-anchor="middle">subClassOf</text>
+  <text x="457" y="166" class="small" text-anchor="middle">SUBCLASSOF · child → parent</text>
+  <path class="tree" d="M194 220V184H420V148"/><path class="tree" d="M457 220V148"/><path class="tree" d="M720 220V184H494V148"/>
+  <rect class="node" x="68" y="220" width="252" height="69" rx="14"/>
+  <text x="194" y="245" class="head" text-anchor="middle">Abnormality of thyroid</text><text x="194" y="265" class="head" text-anchor="middle">physiology</text><text x="194" y="283" class="small" text-anchor="middle">HP:0002926 · 2 levels</text>
+  <rect class="node" x="331" y="220" width="252" height="69" rx="14"/>
+  <text x="457" y="250" class="head" text-anchor="middle">Hypothyroidism</text><text x="457" y="275" class="small" text-anchor="middle">HP:0000821 · 3 levels</text>
+  <rect class="node" x="594" y="220" width="252" height="69" rx="14"/>
+  <text x="720" y="250" class="head" text-anchor="middle">Goiter</text><text x="720" y="275" class="small" text-anchor="middle">HP:0000853 · 3 levels</text>
 
   <rect class="disease" x="72" y="351" width="274" height="69" rx="15"/>
   <text x="209" y="380" class="head" text-anchor="middle">Disease A</text><text x="209" y="403" class="small" text-anchor="middle">하위 표현형에 직접 주석</text>
-  <path class="direct" d="M209 351V297"/>
+  <path class="direct" d="M209 351V289"/>
 
   <rect class="disease" x="652" y="351" width="236" height="69" rx="15"/>
   <text x="770" y="380" class="head" text-anchor="middle">상위 범주 질의</text><text x="770" y="403" class="small" text-anchor="middle">Disease A 포함</text>
   <path class="infer" d="M346 385C485 385 546 385 644 385"/>
   <text x="496" y="371" class="small" text-anchor="middle">계층 경로로 암시적 포함</text>
-  <text x="480" y="451" class="small" text-anchor="middle">추론은 새 임상 사실을 생성하지 않는다. 이미 저장된 주석을 온톨로지의 상·하위 관계를 따라 더 넓은 질의 범위에 포함한다.</text>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/semantic-bridge.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/semantic-bridge.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 365" role="img" aria-labelledby="title desc">
   <title id="title">서로 다른 임상 표현을 온톨로지의 표준 개념으로 연결하는 의미 다리</title>
   <desc id="desc">왼쪽의 동의어, 중의적 약어, 서로 다른 세분성이 매핑을 거쳐 가운데 HPO 표준 식별자와 계층으로 정렬되고 오른쪽의 통합 질의로 이어진다.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0 0 10 5 0 10Z" fill="#617089"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#617089"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:15px;font-weight:800;letter-spacing:1.5px;fill:#49607d}
@@ -14,7 +14,7 @@
       .line{fill:none;stroke:#617089;stroke-width:3;marker-end:url(#arrow)}
     </style>
   </defs>
-  <rect width="960" height="420" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="365" rx="20" fill="#f7f8fa"/>
   <text x="54" y="48" class="eyebrow">LOCAL TERMS</text>
   <text x="362" y="48" class="eyebrow">REFERENCE ONTOLOGY</text>
   <text x="746" y="48" class="eyebrow">ONE QUERY SPACE</text>
@@ -31,9 +31,9 @@
     <text x="68" y="323" class="small">necrosis / lobular necrosis</text>
   </g>
 
-  <path class="line" d="M283 114C330 114 320 143 369 143"/>
-  <path class="line" d="M283 209H369"/>
-  <path class="line" d="M283 304C330 304 320 275 369 275"/>
+  <path class="line" d="M283 114C330 114 326 143 375 143"/>
+  <path class="line" d="M283 209H375"/>
+  <path class="line" d="M283 304C330 304 326 275 375 275"/>
   <text x="319" y="190" class="small" text-anchor="middle">mapping</text>
 
   <rect class="navy" x="375" y="82" width="282" height="242" rx="18"/>
@@ -46,7 +46,7 @@
   <path d="M516 276V300" stroke="#fff" stroke-width="3"/>
   <text x="516" y="306" class="small" text-anchor="middle" style="fill:#fff">subClassOf 계층</text>
 
-  <path class="line" d="M657 203H734"/>
+  <path class="line" d="M657 203H740"/>
   <rect class="box" x="740" y="102" width="172" height="202" rx="16"/>
   <text x="826" y="145" class="head" text-anchor="middle">통합 KG</text>
   <text x="826" y="184" class="label" text-anchor="middle">같은 식별자</text>
@@ -55,5 +55,4 @@
   <path d="M775 265H877" stroke="#0f2c59" stroke-width="2"/>
   <text x="826" y="287" class="small" text-anchor="middle">직접 질의 + 계층 추론</text>
 
-  <text x="480" y="378" class="small" text-anchor="middle">온톨로지는 원천 데이터를 없애지 않는다. 각 로컬 표현이 어떤 표준 개념에 대응하는지 명시하는 공통 의미 계층이다.</text>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/two-sources-one-graph.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/two-sources-one-graph.svg
@@ -1,8 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 440" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" role="img" aria-labelledby="title desc">
   <title id="title">HPO 온톨로지와 주석 데이터를 하나의 지식 그래프로 결합하는 구조</title>
   <desc id="desc">hp.owl은 표현형 정의와 계층을, phenotype.hpoa는 질병과 표현형의 연관 및 증거를 제공하고, 두 원천이 질병 노드, 표현형 노드, 속성 있는 관계로 결합된다.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0 10 5 0 10Z" fill="#66758c"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#66758c"/></marker>
+    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#fff"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.4px;fill:#56677f}
@@ -10,10 +11,10 @@
       .label{font-size:16px;font-weight:700}
       .small{font-size:14px;fill:#526077}
       .box{fill:#fff;stroke:#b6c1d0;stroke-width:2}
-      .line{fill:none;stroke:#66758c;stroke-width:3;marker-end:url(#arrow)}
+      .line{fill:none;stroke:#66758c;stroke-width:3;marker-end:url(#arrow-gray)}
     </style>
   </defs>
-  <rect width="960" height="440" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="400" rx="20" fill="#f7f8fa"/>
   <rect class="box" x="45" y="58" width="270" height="145" rx="16"/>
   <text x="70" y="91" class="eyebrow">SOURCE A · RDF/XML</text>
   <text x="70" y="125" class="head">hp.owl</text>
@@ -26,25 +27,23 @@
   <text x="70" y="337" class="label">질병–표현형 주석</text>
   <text x="70" y="363" class="small">reference · evidence · frequency · curator</text>
 
-  <path class="line" d="M315 130C374 130 382 174 435 174"/>
-  <path class="line" d="M315 310C374 310 382 266 435 266"/>
+  <path class="line" d="M315 130C374 130 388 174 441 174"/>
+  <path class="line" d="M315 310C374 310 388 266 441 266"/>
   <text x="379" y="220" class="small" text-anchor="middle">표준 ID로 결합</text>
 
   <rect x="441" y="70" width="474" height="300" rx="20" fill="#0f2c59"/>
   <text x="678" y="107" class="eyebrow" text-anchor="middle" style="fill:#c9d7e9">ONTOLOGY-GROUNDED LPG</text>
-  <circle cx="573" cy="216" r="62" fill="#fff"/>
-  <text x="573" y="210" class="label" text-anchor="middle">HpoDisease</text>
-  <text x="573" y="235" class="small" text-anchor="middle">OMIM:222100</text>
-  <circle cx="788" cy="216" r="62" fill="#dfe9f6"/>
-  <text x="788" y="210" class="label" text-anchor="middle">HpoPhenotype</text>
-  <text x="788" y="235" class="small" text-anchor="middle">HP:0410050</text>
-  <path d="M635 216H722" stroke="#fff" stroke-width="5" marker-end="url(#arrow)"/>
-  <rect x="623" y="126" width="115" height="61" rx="10" fill="#fff"/>
+  <circle cx="545" cy="216" r="54" fill="#fff"/>
+  <text x="545" y="210" class="label" text-anchor="middle">HpoDisease</text>
+  <text x="545" y="235" class="small" text-anchor="middle">OMIM:222100</text>
+  <circle cx="815" cy="216" r="54" fill="#dfe9f6"/>
+  <text x="815" y="210" class="label" text-anchor="middle">HpoPhenotype</text>
+  <text x="815" y="235" class="small" text-anchor="middle">HP:0410050</text>
+  <path d="M599 216H761" stroke="#fff" stroke-width="5" marker-end="url(#arrow-white)"/>
+  <rect x="602" y="126" width="156" height="61" rx="10" fill="#fff"/>
   <text x="680" y="151" class="small" text-anchor="middle">HAS_PHENOTYPIC</text>
   <text x="680" y="171" class="small" text-anchor="middle">_FEATURE</text>
-  <rect x="571" y="290" width="218" height="49" rx="10" fill="#dfe9f6"/>
+  <rect x="566" y="290" width="228" height="49" rx="10" fill="#dfe9f6"/>
   <text x="680" y="311" class="small" text-anchor="middle">관계 속성: source · evidence</text>
   <text x="680" y="331" class="small" text-anchor="middle">frequency · createdBy · date</text>
-  <path d="M680 278V289" stroke="#dfe9f6" stroke-width="2"/>
-  <text x="480" y="398" class="small" text-anchor="middle">정의·계층은 표현형 노드에, 한 건의 연관을 뒷받침하는 근거는 질병–표현형 관계에 둔다.</text>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/validation-gates.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/validation-gates.svg
@@ -1,19 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 460" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 425" role="img" aria-labelledby="title desc">
   <title id="title">온톨로지 기반 임상 지원 지식 그래프의 네 검증 게이트</title>
   <desc id="desc">원천 스냅샷, 의미 매핑, 적재 보존성, 질의와 추론의 임상 경계를 각각 검증한 뒤 후보 결과를 사람에게 전달하며 실패하면 이전 단계로 되돌아간다.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 0 10 5 0 10Z" fill="#63728a"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
+    <marker id="arrow-red" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#a15b55"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#52647d}
       .head{font-size:18px;font-weight:800}
       .small{font-size:13px;fill:#56657a}
       .gate{fill:#fff;stroke:#b7c2d1;stroke-width:2}
-      .line{fill:none;stroke:#63728a;stroke-width:3;marker-end:url(#arrow)}
-      .return{fill:none;stroke:#a15b55;stroke-width:2.5;stroke-dasharray:7 5;marker-end:url(#arrow)}
+      .line{fill:none;stroke:#63728a;stroke-width:3;marker-end:url(#arrow-gray)}
+      .return{fill:none;stroke:#a15b55;stroke-width:2.5;stroke-dasharray:7 5;marker-end:url(#arrow-red)}
     </style>
   </defs>
-  <rect width="960" height="460" rx="20" fill="#f7f8fa"/>
+  <rect width="960" height="425" rx="20" fill="#f7f8fa"/>
   <text x="480" y="43" class="eyebrow" text-anchor="middle">A QUERY RESULT IS ONLY AS TRUSTWORTHY AS ITS SHORTEST UNCHECKED GATE</text>
   <g>
     <rect class="gate" x="44" y="91" width="196" height="205" rx="16"/>
@@ -46,11 +47,10 @@
     <text x="744" y="174" class="small" style="fill:#dce6f2">대표 질의 재현</text>
     <text x="744" y="199" class="small" style="fill:#dce6f2">추론 범위·깊이</text>
     <text x="744" y="224" class="small" style="fill:#dce6f2">후보와 진단 분리</text>
-    <text x="744" y="263" class="eyebrow" style="fill:#c8d6e8">PASS → HUMAN REVIEW</text>
+    <text x="820" y="263" class="eyebrow" text-anchor="middle" style="fill:#c8d6e8">PASS → HUMAN REVIEW</text>
   </g>
-  <path class="line" d="M240 193H262"/><path class="line" d="M466 193H488"/><path class="line" d="M692 193H714"/>
-  <path class="return" d="M820 303C820 382 580 390 580 305"/>
-  <path class="return" d="M580 303C580 416 357 416 357 305"/>
-  <path class="return" d="M357 303C357 382 143 382 143 305"/>
-  <text x="480" y="435" class="small" text-anchor="middle">게이트를 통과했다는 것은 의료적 타당성까지 자동 증명했다는 뜻이 아니다. 임상의의 검토 가능한 후보와 근거를 만들었다는 뜻이다.</text>
+  <path class="line" d="M240 193H270"/><path class="line" d="M466 193H496"/><path class="line" d="M692 193H722"/>
+  <path class="return" d="M820 296C820 370 580 380 580 296"/>
+  <path class="return" d="M580 296C580 408 357 408 357 296"/>
+  <path class="return" d="M357 296C357 370 143 370 143 296"/>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/index.html
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/index.html
@@ -110,7 +110,7 @@
       <footer class="slide-footer"><a class="report-ref" href="report.html#fig-two-sources">상세 리포트 그림 2 · 두 원천의 결합</a><span><b data-slide-number></b> / <b data-slide-total></b></span></footer>
     </section>
 
-    <section class="slide" aria-label="두 원천의 입력 계약" data-report-refs="data-technology table-source-contract">
+    <section class="slide" aria-label="두 원천의 입력 계약" data-report-refs="data-technology table-source-contract table-build-steps">
       <header class="slide-header"><span class="brand-name">ds4th study</span><span class="section-tag">DATA CONTRACT</span></header>
       <h1>어느 파일에서 무엇이 정본인지 먼저 고정한다</h1>
       <p class="lead">두 원천은 형식뿐 아니라 변경 영향과 검증 단위가 다릅니다.</p>
@@ -211,12 +211,14 @@
     <section class="slide" aria-label="코드 감사와 재현 경계" data-report-refs="build-operate implementation-reality table-implementation-audit">
       <header class="slide-header"><span class="brand-name">ds4th study</span><span class="section-tag">IMPLEMENTATION AUDIT</span></header>
       <h1>책의 결과와 현재 실행 결과가 다른 이유를 설명할 수 있어야 한다</h1>
-      <p class="lead">원자료·코드 감사에서 네 가지 재현 경계를 확인했습니다.</p>
+      <p class="lead">원자료·교재·실습 코드를 대조해 여섯 가지 재현 경계를 확인했습니다.</p>
       <div class="slide-body">
-        <div class="audit-grid">
-          <article><span>DATA DRIFT</span><h2>2025-02 → 2026-06-23</h2><p>latest HPOA는 건수와 후보 순위를 바꿀 수 있다.</p></article>
+        <div class="audit-grid audit-grid--six">
+          <article><span>DATA DRIFT</span><h2>899,558은 기준값</h2><p>교재 2025-02 적재 건수이며 2026-06-23 latest와 같지 않다.</p></article>
           <article><span>ANNOTATION LOSS</span><h2>쌍 단위 MERGE</h2><p>같은 질병–표현형 쌍의 여러 근거가 덮일 수 있다.</p></article>
-          <article><span>STAGE DEPENDENCY</span><h2>정제 전용 질의</h2><p>Listing 3.18은 최종 정제 뒤 같은 형태로 실행되지 않는다.</p></article>
+          <article><span>STAGE DEPENDENCY</span><h2>정제 뒤 실패</h2><p>Listing 3.18은 최종 정제 뒤 같은 형태로 실행하면 실패한다.</p></article>
+          <article><span>QUERY SIDE EFFECT</span><h2>읽기 질의의 MERGE</h2><p>Listing 3.21은 미바인딩 관계를 만들 수 있어 <code>MATCH</code>로 고친다.</p></article>
+          <article><span>RESULT SUBSET</span><h2>화이트리스트 ≠ SKIP</h2><p>교재 3.28과 소스 3.31은 결과 제한 방식이 달라 출력이 다르다.</p></article>
           <article><span>LISTING MAP</span><h2>교재 ↔ 소스 +3</h2><p><code>study.toml</code> 전수 대응표가 리스팅 정본이다.</p></article>
         </div>
         <p class="takeaway"><strong>재현성</strong> — 릴리스 URL·체크섬·적재 단계·질의 버전을 결과와 함께 저장합니다.</p>
@@ -240,24 +242,31 @@
       <footer class="slide-footer"><a class="report-ref" href="report.html#fig-clinical-query">상세 리포트 그림 6 · 후보 질의</a><span><b data-slide-number></b> / <b data-slide-total></b></span></footer>
     </section>
 
-    <section class="slide" aria-label="후보 랭킹의 해석 경계" data-report-refs="query-case table-candidate-results">
+    <section class="slide" aria-label="후보 랭킹의 해석 경계" data-report-refs="query-case direct-query table-candidate-results">
       <header class="slide-header"><span class="brand-name">ds4th study</span><span class="section-tag">QUERY RESULT</span></header>
-      <h1><code>count(*)</code>는 진단 확률이 아니라 겹침 수다</h1>
-      <p class="lead">책의 상위 결과를 무엇이 보장되고 무엇이 빠졌는지 함께 읽습니다.</p>
+      <h1>다섯 표현형의 겹침 수를 집계하고 이름으로 동률을 푼다</h1>
+      <p class="lead"><code>count(nodes)</code>는 주석 경로 수이며 진단 확률이 아닙니다.</p>
       <div class="slide-body query-strip">
         <pre><code class="language-cypher">MATCH (phe:HpoPhenotype)
-WHERE phe.label IN $observed
-MATCH (dis:HpoDisease)
+WHERE phe.label IN [
+  "Growth delay", "Large knee",
+  "Sensorineural hearing impairment", "Pruritus",
+  "Type I diabetes mellitus"
+]
+WITH phe
+MATCH path=(dis:HpoDisease)
   -[:HAS_PHENOTYPIC_FEATURE]-&gt;(phe)
-RETURN dis.label,
+UNWIND dis AS nodes
+RETURN dis.id AS disease_id,
+       dis.label AS disease_name,
        collect(phe.label) AS features,
-       count(*) AS overlap
-ORDER BY overlap DESC
+       count(nodes) AS num_of_features
+ORDER BY num_of_features DESC, disease_name
 LIMIT 5</code></pre>
         <div class="ranking-list">
-          <article><b>5/5</b><div><p>Odontochondrodysplasia 2 …</p><small>다섯 주석 경로 모두 존재</small></div></article>
-          <article><b>3/5</b><div><p>Holoprosencephaly 12 …</p><small>세 주석 경로 공유</small></div></article>
-          <article><b>2/5</b><div><p>여러 후보 동률</p><small>추가 근거·검사가 필요</small></div></article>
+          <article><b>5/5</b><div><p>Odontochondrodysplasia 2 …</p><small>OMIM:619269 · 다섯 주석 경로</small></div></article>
+          <article><b>3/5</b><div><p>Holoprosencephaly 12 …</p><small>OMIM:618500 · 세 주석 경로</small></div></article>
+          <article><b>2/5</b><div class="tie-list"><small>3-methylglutaconic aciduria VIII · OMIM:614700</small><small>Alobar holoprosencephaly · OMIM:616192</small><small>Alpha-thalassemia/mental retardation, X-linked · OMIM:602782</small></div></article>
         </div>
       </div>
       <p class="takeaway"><strong>빠진 것</strong> — 희귀도·부정 소견·발현 시점·증거 질·환자 맥락은 이 단순 랭킹에 포함되지 않습니다.</p>
@@ -269,8 +278,8 @@ LIMIT 5</code></pre>
       <h1>계층은 하위 표현형의 주석을 상위 범주 질의에 포함한다</h1>
       <div class="slide-body">
         <figure class="deck-report-figure">
-          <img src="assets/figs/hierarchical-inference.svg" alt="내분비계 이상 상위 범주 아래의 갑상선 췌장 포도당 대사 이상 하위 개념과 연결된 질병이 상위 범주 질의에 포함되는 구조">
-          <figcaption><b>직접 사실 + 암시적 포함</b><span>질병은 하위 표현형에 직접 주석</span><span><code>SUBCLASSOF</code>가 상위 범주를 연결</span><span>새 사실 생성이 아니라 질의 범위 확장</span></figcaption>
+          <img src="assets/figs/hierarchical-inference.svg" alt="갑상선 생리 이상, 갑상선기능저하증, 갑상선종에서 내분비계 이상 상위 범주로 향하는 자식에서 부모 방향의 SUBCLASSOF 관계와 상위 범주 질의 포함 구조">
+          <figcaption><b>직접 사실 + 암시적 포함</b><span>질병은 하위 표현형에 직접 주석</span><span><code>SUBCLASSOF</code> 저장 방향은 자식→부모</span><span>상위 범주에서 역방향으로 1–3단계를 탐색</span></figcaption>
         </figure>
       </div>
       <footer class="slide-footer"><a class="report-ref" href="report.html#fig-hierarchical-inference">상세 리포트 그림 7 · 계층 추론</a><span><b data-slide-number></b> / <b data-slide-total></b></span></footer>
@@ -311,6 +320,25 @@ LIMIT 5</code></pre>
       <footer class="slide-footer"><a class="report-ref" href="report.html#fig-validation-gates">상세 리포트 그림 8 · 검증 게이트</a><span><b data-slide-number></b> / <b data-slide-total></b></span></footer>
     </section>
 
+    <section class="slide" aria-label="임상 안전 경계" data-report-refs="evidence-limits medical-boundary table-failure-modes">
+      <header class="slide-header"><span class="brand-name">ds4th study</span><span class="section-tag">SAFETY BOUNDARY</span></header>
+      <h1>이 장의 결과는 진단이 아니라 검토 가능한 후보 생성이다</h1>
+      <p class="lead">기술적으로 재현된 경로도 실제 임상 의사결정의 안전성과 유효성을 자동 증명하지 않습니다.</p>
+      <div class="slide-body">
+        <div class="fact-grid fact-grid--safety">
+          <article><span>SCOPE</span><h2>교육용 개념 증명</h2><p>HPO 위에서 질의와 계층 추론이 작동하는 방식을 보여준다.</p></article>
+          <article><span>DATA GOVERNANCE</span><h2>EHR·동의·권한 부재</h2><p>실제 환자 수집, 비식별화, 접근 통제는 이 장의 범위 밖이다.</p></article>
+          <article><span>CLINICAL CONTEXT</span><h2>부정·시점·빈도 부재</h2><p>부정 표현형, 발현 시점, 환자군별 빈도를 단순 겹침 수가 반영하지 않는다.</p></article>
+          <article><span>ACCOUNTABILITY</span><h2>검증·규제·책임 부재</h2><p>임상 검증과 규제 준수, 최종 판단 책임은 별도 절차로 남는다.</p></article>
+        </div>
+        <div class="safety-flow" aria-label="후보명, 원 주석과 추론 경로, 데이터 버전을 함께 제시하고 임상의 검토로 넘기며 진단 확정과 구분한다">
+          <span>후보명</span><b>+</b><span>원 주석·추론 경로</span><b>+</b><span>데이터 버전</span><b>→</b><strong>임상의 검토</strong><em>≠ 진단 확정</em>
+        </div>
+        <p class="takeaway"><strong>안전 원칙</strong> — 질병명만 내보내지 말고 원 주석·추론 경로·데이터 버전을 함께 보여준 뒤 사람의 검토로 넘깁니다.</p>
+      </div>
+      <footer class="slide-footer"><a class="report-ref" href="report.html#medical-boundary">상세 리포트 §6.2 · 임상 안전 경계</a><span><b data-slide-number></b> / <b data-slide-total></b></span></footer>
+    </section>
+
     <section class="slide" aria-label="온톨로지 기반 KG 도입 판단" data-report-refs="decision technology-decision table-decision">
       <header class="slide-header"><span class="brand-name">ds4th study</span><span class="section-tag">DECISION GUIDE</span></header>
       <h1>온톨로지와 그래프는 질문에 필요한 만큼만 쓴다</h1>
@@ -325,7 +353,7 @@ LIMIT 5</code></pre>
       <footer class="slide-footer"><a class="report-ref" href="report.html#table-decision">상세 리포트 표 10 · 도입 판단</a><span><b data-slide-number></b> / <b data-slide-total></b></span></footer>
     </section>
 
-    <section class="slide" aria-label="발표 정리 질문" data-report-refs="decision discussion table-discussion table-glossary">
+    <section class="slide" aria-label="발표 정리 질문" data-report-refs="decision discussion table-discussion">
       <header class="slide-header"><span class="brand-name">ds4th study</span><span class="section-tag">CHECKPOINT</span></header>
       <h1>세 질문으로 우리 시스템의 책임을 드러낸다</h1>
       <p class="lead">용어 암기보다 설계 결정을 말할 수 있는지 확인합니다.</p>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/report.html
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/report.html
@@ -124,7 +124,7 @@
       <figure class="report-figure" id="fig-two-sources" data-deck-use="required">
         <figcaption class="asset-caption asset-caption--figure"><span class="asset-caption__chip">그림 2</span><span class="asset-caption__title">정의·계층과 연관·근거를 한 그래프에 결합하기</span></figcaption>
         <img src="assets/figs/two-sources-one-graph.svg" alt="hp.owl의 표현형 정의와 계층, phenotype.hpoa의 질병 표현형 연관과 근거가 표준 ID로 결합되어 질병 노드, 표현형 노드, 속성 있는 관계를 만드는 구조">
-        <small class="asset-note">교재 §3.1.2, 그림 3.5–3.6과 Listing 3.1–3.4의 의미를 새로 배치. 원본 도형을 복제하지 않음.</small>
+        <small class="asset-note">교재 §3.1.2, 그림 3.5–3.6과 Listing 3.1–3.4의 의미를 새로 배치. 정의·계층은 표현형 노드에, 한 건의 연관을 뒷받침하는 근거는 질병–표현형 관계에 둔다. 원본 도형을 복제하지 않음.</small>
       </figure>
       <table class="cmp-table" id="table-source-contract">
         <caption class="cmp-table__caption asset-caption asset-caption--table"><div class="asset-caption__inner"><span class="asset-caption__chip">표 3</span><span class="asset-caption__title">HPO 두 원천의 입력 계약</span></div></caption>
@@ -143,7 +143,7 @@
       <figure class="report-figure" id="fig-edge-metadata" data-deck-use="required">
         <figcaption class="asset-caption asset-caption--figure"><span class="asset-caption__chip">그림 3</span><span class="asset-caption__title">같은 주석 메타데이터를 표현하는 네 가지 패턴</span></figcaption>
         <img src="assets/figs/edge-metadata-options.svg" alt="RDF n항 관계, RDF 명명 그래프, RDF-star, LPG 관계 속성이 질병 표현형 연결의 출처 작성자 날짜를 각기 다른 구조로 표현하는 비교">
-        <small class="asset-note">교재 §3.2.2, Listing 3.5–3.12의 구조를 관계 메타데이터라는 동일 질문으로 재구성.</small>
+        <small class="asset-note">교재 §3.2.2, Listing 3.5–3.12의 구조를 관계 메타데이터라는 동일 질문으로 재구성. n항 관계는 Annotation 자원에서 질병·표현형으로 나가는 관계를, 명명 그래프는 문장 묶음의 맥락을, RDF-star는 인용된 트리플의 메타데이터를, LPG는 개별 관계의 키–값을 보여준다.</small>
       </figure>
       <table class="cmp-table" id="table-rdf-lpg">
         <caption class="cmp-table__caption asset-caption asset-caption--table"><div class="asset-caption__inner"><span class="asset-caption__chip">표 4</span><span class="asset-caption__title">RDF와 LPG의 선택 기준</span></div></caption>
@@ -171,20 +171,21 @@
       <figure class="report-figure" id="fig-build-pipeline" data-deck-use="required">
         <figcaption class="asset-caption asset-caption--figure"><span class="asset-caption__chip">그림 4</span><span class="asset-caption__title">임상 질문에서 검증된 그래프 질의까지</span></figcaption>
         <img src="assets/figs/build-pipeline.svg" alt="임상 질문, HPO 두 원천 이해, RDF LPG 선택, 온톨로지 적재, 주석 적재, 정제와 점검, 직접 질의와 계층 추론이 검증 게이트를 거쳐 이어지는 파이프라인">
-        <small class="asset-note">교재 그림 3.1–3.2, 3.7, 3.9–3.10의 전체 흐름을 산출물과 검증 지점 중심으로 통합 재구성.</small>
+        <small class="asset-note">교재 그림 3.1–3.2, 3.7, 3.9–3.10의 전체 흐름을 산출물과 검증 지점 중심으로 통합 재구성. 각 단계가 남겨야 할 산출물은 대표 질문, 원천 계약, 모델 선택 근거, 적재 로그, 품질 점검과 재현 가능한 질의다.</small>
       </figure>
       <table class="cmp-table" id="table-build-steps">
-        <caption class="cmp-table__caption asset-caption asset-caption--table"><div class="asset-caption__inner"><span class="asset-caption__chip">표 5</span><span class="asset-caption__title">구축 단계별 입력·출력·확인 질문</span></div></caption>
+        <caption class="cmp-table__caption asset-caption asset-caption--table"><div class="asset-caption__inner"><span class="asset-caption__chip">표 5</span><span class="asset-caption__title">설계 이후 여섯 구축 단계의 입력·출력·확인 질문</span></div></caption>
         <thead><tr><th>단계</th><th>주요 작업</th><th>출력</th><th>품질 확인</th></tr></thead>
         <tbody>
           <tr><td>DB 준비</td><td>DB 생성, URI/ID 유일성 제약, ID 인덱스</td><td>중복을 거부하는 저장 공간</td><td>제약 충돌과 기존 데이터 상태</td></tr>
           <tr><td>n10s 설정</td><td>그래프 설정, URI 처리와 Neo4j 명명 규칙 지정</td><td>RDF→LPG 변환 규칙</td><td>namespace를 무시해도 충돌하지 않는가</td></tr>
-          <tr><td>온톨로지 적재</td><td><code>n10s.rdf.import.fetch</code>, phenotype label·ID 부여</td><td>표현형 정의와 계층</td><td>URI·ID·<code>SUBCLASSOF</code> 건수</td></tr>
+          <tr><td>온톨로지 적재</td><td><code>n10s.rdf.import.fetch</code>, phenotype label·ID 부여</td><td>표현형 정의와 계층</td><td>교재 기준 899,558 statements와 URI·ID·<code>SUBCLASSOF</code> 건수 비교<sup>*</sup></td></tr>
           <tr><td>주석 적재</td><td>질병 노드와 <code>HAS_PHENOTYPIC_FEATURE</code> 생성</td><td>두 원천의 연결</td><td>매칭 실패·중복·누락 건수</td></tr>
           <tr><td>풍부화</td><td>evidence·frequency·biocuration 파싱과 URL 생성</td><td>검토 가능한 관계 속성</td><td>결측·복수값·정규식 실패</td></tr>
           <tr><td>정제</td><td>사용하지 않는 Resource 노드 제거</td><td>질의 중심 그래프</td><td>추론·감사에 필요한 정보까지 지우지 않았는가</td></tr>
         </tbody>
       </table>
+      <p class="asset-note"><sup>*</sup> 899,558은 Neo4j/APOC/n10s 5.20.0과 HPO 2025-02를 사용한 교재 실행값이다. 현재 릴리스의 정답 건수가 아니라 스냅샷 재현 기준선으로 사용한다.</p>
 
       <h3 id="annotation-lifecycle">3.2 한 행을 한 건의 감사 가능한 주장으로 보존한다</h3>
       <p>교재의 Cypher는 TSV를 읽어 질병과 표현형을 <code>MERGE</code>하고, 관계가 만들어진 뒤 원시 필드와 사람이 읽을 설명을 순차적으로 추가한다. <code>FOREACH(CASE …)</code> 패턴은 값이 있는 필드만 설정해 null로 기존 값을 덮지 않는다. APOC 정규식은 <code>biocuration</code>에서 큐레이터와 날짜를 뽑고, 증거 코드 IEA·PCS·TAS를 설명으로 바꾼다.</p>
@@ -198,7 +199,7 @@ FOREACH (_ IN CASE WHEN row[5] IS NOT NULL THEN [1] ELSE [] END |
       <figure class="report-figure" id="fig-annotation-lifecycle" data-deck-use="required">
         <figcaption class="asset-caption asset-caption--figure"><span class="asset-caption__chip">그림 5</span><span class="asset-caption__title">HPOA 한 행이 그래프 주장이 되는 생애주기</span></figcaption>
         <img src="assets/figs/annotation-lifecycle.svg" alt="HPOA 행을 파싱하고 표준 ID로 노드를 매칭해 관계를 만든 뒤 증거 설명과 URL로 풍부화하고 건수와 근거 보존을 확인하는 단계">
-        <small class="asset-note">교재 Listing 3.19–3.24와 저장소 <code>import_hpo.py</code> 감사를 바탕으로 재구성. 아래 구현 위험은 발표자의 코드 감사 결과.</small>
+        <small class="asset-note">교재 Listing 3.19–3.24와 저장소 <code>import_hpo.py</code> 감사를 바탕으로 재구성. 같은 질병–표현형 쌍의 주석이 여러 건이면 관계 식별자 없이 <code>MERGE</code>한 한 관계에 마지막 값이 덮일 수 있다는 구현 위험은 발표자의 코드 감사 결과다.</small>
       </figure>
 
       <h3 id="implementation-reality">3.3 책의 결과와 현재 실행 결과는 분리한다</h3>
@@ -212,6 +213,8 @@ FOREACH (_ IN CASE WHEN row[5] IS NOT NULL THEN [1] ELSE [] END |
           <tr><td>주석 다중성</td><td>질병–표현형 쌍만으로 관계 <code>MERGE</code></td><td>여러 provenance가 한 관계에서 덮일 수 있음</td><td>주석 식별자 또는 Annotation 노드</td></tr>
           <tr><td>파싱 가정</td><td>큐레이터·날짜 정규식이 첫 패턴을 기대</td><td>결측·복수값에서 오류 또는 정보 손실</td><td>파싱 실패율과 원문 보존</td></tr>
           <tr><td>단계 의존</td><td>중간 조회는 최종 정제 뒤 실패</td><td>실행 순서에 따라 데모 결과가 달라짐</td><td>단계별 스냅샷 또는 독립 검증 질의</td></tr>
+          <tr><td>조회 부작용</td><td>Listing 3.21이 조회 목적에 미바인딩 <code>MERGE</code> 사용</td><td>노드·관계가 새로 생겨 그래프 오염</td><td><code>MATCH</code>로 교정하고 실행 전 스냅샷 보존</td></tr>
+          <tr><td>추론 결과 고정</td><td>교재 3.28은 5개 질병 화이트리스트, 저장소 3.31은 <code>SKIP 100 LIMIT 5</code></td><td>같은 추론도 표시되는 부분집합이 다름</td><td>필터·정렬·페이지 기준을 결과와 함께 기록</td></tr>
           <tr><td>리스팅 번호</td><td>업스트림 ch03 파일은 교재 번호와 +3</td><td>잘못된 코드 참조 위험</td><td><code>study.toml</code> 전수 대응표 사용</td></tr>
         </tbody>
       </table>
@@ -227,34 +230,38 @@ FOREACH (_ IN CASE WHEN row[5] IS NOT NULL THEN [1] ELSE [] END |
       </ul></div></div>
 
       <h3 id="direct-query">4.1 직접 연결은 답보다 검토 경로를 준다</h3>
-      <p>첫 질의는 <code>OMIM:222100</code> 제1형 당뇨병 노드에 직접 연결된 표현형을 가져온다. 이어 임상의가 환자에게서 성장 지연, 큰 무릎, 감각신경성 청각 장애, 소양증을 추가로 관찰했다고 가정한다. 두 번째 질의는 다섯 표현형과 연결된 질병을 모으고, 겹치는 특징 수를 내림차순으로 정렬한다.</p>
+      <p>첫 질의는 <code>OMIM:222100</code> 제1형 당뇨병 노드에 직접 연결된 표현형을 가져온다. 이어 임상의가 환자에게서 성장 지연(<code>HP:0001510</code>), 큰 무릎(<code>HP:0030866</code>), 감각신경성 청각 장애(<code>HP:0000407</code>), 소양증(<code>HP:0000989</code>)을 추가로 관찰했다고 가정한다. 두 번째 질의는 다섯 표현형과 연결된 질병을 모으고, 겹치는 특징 수를 내림차순으로 정렬한다.</p>
       <pre><code class="language-cypher">MATCH (phe:HpoPhenotype)
 WHERE phe.label IN [
   "Growth delay", "Large knee",
   "Sensorineural hearing impairment", "Pruritus",
   "Type I diabetes mellitus"
 ]
-MATCH (dis:HpoDisease)-[:HAS_PHENOTYPIC_FEATURE]-&gt;(phe)
-RETURN dis.id, dis.label, collect(phe.label) AS features,
-       count(*) AS num_of_features
-ORDER BY num_of_features DESC, dis.label
+WITH phe
+MATCH path=(dis:HpoDisease)-[:HAS_PHENOTYPIC_FEATURE]-&gt;(phe)
+UNWIND dis AS nodes
+RETURN dis.id AS disease_id,
+       dis.label AS disease_name,
+       collect(phe.label) AS features,
+       count(nodes) AS num_of_features
+ORDER BY num_of_features DESC, disease_name
 LIMIT 5</code></pre>
       <p>교재의 2025년 2월 스냅샷에서는 다섯 특징을 모두 공유하는 <em>Odontochondrodysplasia 2 with hearing loss and diabetes</em>(OMIM:619269)가 첫 후보로 나타난다. 그다음 후보는 세 개 또는 두 개의 특징을 공유한다. 그래프의 가치는 질병 이름만 반환하는 데 있지 않다. 어떤 표현형 경로가 점수를 만들었는지, 각 관계에 어떤 출처·증거·빈도가 있는지 다시 열어볼 수 있다.</p>
       <figure class="report-figure" id="fig-clinical-query" data-deck-use="required">
         <figcaption class="asset-caption asset-caption--figure"><span class="asset-caption__chip">그림 6</span><span class="asset-caption__title">관찰한 다섯 표현형으로 질병 후보를 순위화하기</span></figcaption>
         <img src="assets/figs/clinical-query.svg" alt="제1형 당뇨병과 성장 지연, 큰 무릎, 감각신경성 청각 장애, 소양증이 연결된 질병 후보들을 공유 특징 수 5개, 3개, 2개 순으로 정렬하는 구조">
-        <small class="asset-note">교재 §3.4, Listing 3.25–3.26과 표 3.2를 경로와 겹침 수 중심으로 재구성. 질병명과 수치는 교재의 HPO 2025-02 결과 스냅샷.</small>
+        <small class="asset-note">교재 §3.4, Listing 3.25–3.26과 표 3.2를 경로와 겹침 수 중심으로 재구성. 선은 후보 랭킹에서 공유 주석의 존재만 나타내며 관계 방향은 그림 2의 질병→표현형을 따른다. 질병명과 수치는 HPO 2025-02 교재 스냅샷이며, 교재의 <em>Ondontochondrodysplasia</em> 오타는 OMIM:619269의 정식 표기 <em>Odontochondrodysplasia</em>로 교정했다.</small>
       </figure>
       <table class="cmp-table" id="table-candidate-results">
         <caption class="cmp-table__caption asset-caption asset-caption--table"><div class="asset-caption__inner"><span class="asset-caption__chip">표 7</span><span class="asset-caption__title">교재 스냅샷의 상위 후보와 해석 경계</span></div></caption>
         <thead><tr><th>후보</th><th>공유 특징</th><th>이 결과가 말하는 것</th><th>말하지 않는 것</th></tr></thead>
         <tbody>
           <tr><td>Odontochondrodysplasia 2 with hearing loss and diabetes</td><td>5</td><td>입력 다섯 표현형 모두와 주석 경로가 있음</td><td>환자가 이 질병일 확률 또는 확정 진단</td></tr>
-          <tr><td>Holoprosencephaly 12 with/without pancreatic agenesis</td><td>3</td><td>세 표현형을 공유하는 비교 후보</td><td>세 특징의 특이도·중요도가 같다는 뜻</td></tr>
-          <tr><td>여러 2개 공유 후보</td><td>2</td><td>추가 검사·근거 검토가 필요한 넓은 후보군</td><td>빈도·부정 표현형·환자 맥락을 반영한 랭킹</td></tr>
+          <tr><td>Holoprosencephaly 12 with or without pancreatic agenesis (OMIM:618500)</td><td>3</td><td>세 표현형을 공유하는 비교 후보</td><td>세 특징의 특이도·중요도가 같다는 뜻</td></tr>
+          <tr><td>3-methylglutaconic aciduria VIII (OMIM:614700), Alobar holoprosencephaly (OMIM:616192), Alpha-thalassemia/mental retardation syndrome, X-linked (OMIM:602782)</td><td>각 2</td><td>교재 스냅샷의 동률 3건</td><td>빈도·부정 표현형·환자 맥락을 반영한 랭킹</td></tr>
         </tbody>
       </table>
-      <div class="callout--insight"><span class="callout__kicker">임상 경계</span><div class="callout__body"><p>단순 <code>count(*)</code>는 표현형의 희귀도, 부정 소견, 발현 시점, 증거 질, 환자 인구집단을 가중하지 않는다. 결과 화면은 후보·경로·근거를 함께 보여주고 임상의의 다음 검토를 지원해야 한다.</p></div></div>
+      <div class="callout--insight"><span class="callout__kicker">임상 경계</span><div class="callout__body"><p>단순 겹침 수 <code>count(nodes)</code>는 표현형의 희귀도, 부정 소견, 발현 시점, 증거 질, 환자 인구집단을 가중하지 않는다. 결과 화면은 후보·경로·근거를 함께 보여주고 임상의의 다음 검토를 지원해야 한다.</p></div></div>
     </section>
 
     <section class="report-section s5 page-break" id="reasoning">
@@ -267,12 +274,12 @@ LIMIT 5</code></pre>
       </ul></div></div>
 
       <h3 id="explicit-inferred">5.1 직접 사실과 암시적 포함을 분리한다</h3>
-      <p>“내분비계 이상과 관련된 질병은?”이라는 질문을 생각해 보자. 어떤 질병은 <em>Abnormality of the endocrine system</em>에 직접 주석되어 있지만, 더 많은 질병은 갑상선·췌장·포도당 대사처럼 하위 표현형에 연결되어 있다. 직접 관계만 조회하면 후자를 놓친다.</p>
-      <p>교재는 먼저 <code>[:SUBCLASSOF*1..3]</code> 경로로 상위 범주 아래의 하위 표현형을 찾고, 이어 <code>n10s.inference.nodesInCategory</code>로 이 계층을 따라 질병을 포함한다. 반환된 질병–표현형 주석은 원래 그래프에 명시적으로 존재하지만, 상위 범주와 질병의 포함 관계는 계층 규칙에서 도출된다.</p>
+      <p>“내분비계 이상(<em>Abnormality of the endocrine system</em>, <code>HP:0000818</code>)과 관련된 질병은?”이라는 질문을 생각해 보자. 어떤 질병은 이 상위 범주에 직접 주석되어 있지만, 더 많은 질병은 갑상선 생리 이상(<code>HP:0002926</code>), 갑상선기능저하증(<code>HP:0000821</code>), 갑상선종(<code>HP:0000853</code>)처럼 검증된 하위 표현형에 연결되어 있다. 직접 관계만 조회하면 후자를 놓친다.</p>
+      <p>교재는 먼저 자식에서 부모로 향하는 <code>[:SUBCLASSOF*1..3]</code> 경로를 역방향으로 탐색해 상위 범주 아래의 하위 표현형을 찾고, 이어 <code>n10s.inference.nodesInCategory</code>로 이 계층을 따라 질병을 포함한다. 반환된 질병–표현형 주석은 원래 그래프에 명시적으로 존재하지만, 상위 범주와 질병의 포함 관계는 계층 규칙에서 도출된다. 교재 표 3.3은 재현성을 위해 5개 질병 화이트리스트로 제한한 부분집합이고, 저장소 Listing 3.31은 화이트리스트 대신 <code>SKIP 100 LIMIT 5</code>를 사용하므로 표시 결과가 같지 않다.</p>
       <figure class="report-figure" id="fig-hierarchical-inference" data-deck-use="required">
         <figcaption class="asset-caption asset-caption--figure"><span class="asset-caption__chip">그림 7</span><span class="asset-caption__title">하위 표현형 주석을 상위 범주 질의에 포함하기</span></figcaption>
-        <img src="assets/figs/hierarchical-inference.svg" alt="내분비계 이상 상위 범주 아래 갑상선, 췌장, 포도당 대사 이상이 있고 질병이 하위 표현형에 직접 연결되어 상위 범주 질의에 추론으로 포함되는 구조">
-        <small class="asset-note">교재 §3.5, Listing 3.27–3.28과 표 3.3의 의미를 직접 사실과 암시적 포함으로 구분해 재구성.</small>
+        <img src="assets/figs/hierarchical-inference.svg" alt="갑상선 생리 이상, 갑상선기능저하증, 갑상선종에서 내분비계 이상 상위 범주로 향하는 SUBCLASSOF 관계가 있고, 하위 표현형에 직접 주석된 질병이 상위 범주 질의에 추론으로 포함되는 구조">
+        <small class="asset-note">교재 §3.5, Listing 3.27–3.28과 표 3.3의 의미를 직접 사실과 암시적 포함으로 구분해 재구성. 화살표는 HPO 저장 방향과 같은 하위→상위 <code>SUBCLASSOF</code>이며, 세 예시는 HPO Ontology Service 2026-06-23 기준 <code>HP:0000818</code>의 2–3단계 하위임을 확인했다. 추론은 새 임상 사실을 만들지 않고 기존 주석의 질의 범위를 넓힌다.</small>
       </figure>
 
       <h3 id="reasoning-boundary">5.2 더 넓은 결과가 더 정확한 결과는 아니다</h3>
@@ -304,7 +311,7 @@ LIMIT 5</code></pre>
       <figure class="report-figure" id="fig-validation-gates" data-deck-use="required">
         <figcaption class="asset-caption asset-caption--figure"><span class="asset-caption__chip">그림 8</span><span class="asset-caption__title">온톨로지 기반 임상 지원 KG의 네 검증 게이트</span></figcaption>
         <img src="assets/figs/validation-gates.svg" alt="원천, 의미, 적재, 사용의 네 검증 게이트를 차례로 통과하고 실패하면 이전 단계로 돌아가며 최종 결과는 사람 검토로 이어지는 구조">
-        <small class="asset-note">교재의 데이터 품질 강조와 Chapter 3 구현 감사를 운영 통제 관점으로 재구성.</small>
+        <small class="asset-note">교재의 데이터 품질 강조와 Chapter 3 구현 감사를 운영 통제 관점으로 재구성. 게이트 통과는 의료적 타당성의 자동 증명이 아니라 임상의가 검토할 후보와 근거를 만들었다는 뜻이다.</small>
       </figure>
       <table class="cmp-table" id="table-failure-modes">
         <caption class="cmp-table__caption asset-caption asset-caption--table"><div class="asset-caption__inner"><span class="asset-caption__chip">표 9</span><span class="asset-caption__title">주장–조건–실패 신호 추적표</span></div></caption>


### PR DESCRIPTION
## 변경 내용

- Chapter 3 상세 리포트의 근거·재현 경계·임상 안전 설명을 보강했습니다.
- 발표자료의 감사·질의·안전 슬라이드를 다듬었습니다.
- 8개 SVG 도형의 레이아웃과 방향 표현을 조정했습니다.

## 영향

Chapter 3 리포트와 발표자료의 기존 공개 URL은 유지되며, 내용 밀도와 시각적 전달력이 개선됩니다.

## 검증

- `python3 agent-support/scripts/build-index.py`
- `python3 agent-support/scripts/build-index.py --check`
- `python3 agent-support/scripts/validate-site.py --check-materials`
- `git diff --check`
- 27장 1280×720 렌더링, 이미지 로드, 키보드 이동, 설정 링크, 390px 축소 확인