### PR TITLE
Fix Chapter 3 SVG arrow routing

### DIFF
--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/annotation-lifecycle.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/annotation-lifecycle.svg
@@ -2,7 +2,7 @@
   <title id="title">HPOA 한 행이 추적 가능한 그래프 관계가 되는 생애주기</title>
   <desc id="desc">TSV 한 행에서 질병과 표현형 ID를 매칭하고 관계를 생성한 뒤 원시 근거 필드를 추가하고 사람이 읽는 설명과 URL로 풍부화하며 품질 점검을 거친다.</desc>
   <defs>
-    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#53647d}
@@ -15,41 +15,41 @@
   <rect width="960" height="285" rx="20" fill="#f7f8fa"/>
   <text x="480" y="42" class="eyebrow" text-anchor="middle">ONE HPOA ROW → ONE AUDITABLE ASSERTION</text>
   <g>
-    <rect class="box" x="35" y="78" width="166" height="175" rx="15"/>
-    <text x="55" y="108" class="eyebrow">01 · PARSE</text>
-    <text x="55" y="138" class="head">TSV 한 행</text>
-    <text x="55" y="170" class="small">database_id</text>
-    <text x="55" y="192" class="small">hpo_id</text>
-    <text x="55" y="214" class="small">reference · evidence</text>
-    <text x="55" y="236" class="small">frequency · biocuration</text>
+    <rect class="box" x="23" y="78" width="154" height="175" rx="15"/>
+    <text x="40" y="108" class="eyebrow">01 · PARSE</text>
+    <text x="40" y="138" class="head">TSV 한 행</text>
+    <text x="40" y="170" class="small">database_id</text>
+    <text x="40" y="192" class="small">hpo_id</text>
+    <text x="40" y="214" class="small">reference · evidence</text>
+    <text x="40" y="236" class="small" style="font-size:12px">frequency · biocuration</text>
 
-    <rect class="box" x="224" y="78" width="166" height="175" rx="15"/>
-    <text x="244" y="108" class="eyebrow">02 · MATCH</text>
-    <text x="244" y="138" class="head">표준 ID 정렬</text>
-    <text x="244" y="175" class="small">HpoDisease</text>
-    <text x="244" y="197" class="small">HpoPhenotype</text>
-    <text x="244" y="229" class="small">없음 · 중복 · 형식 오류?</text>
+    <rect class="box" x="213" y="78" width="154" height="175" rx="15"/>
+    <text x="233" y="108" class="eyebrow">02 · MATCH</text>
+    <text x="233" y="138" class="head">표준 ID 정렬</text>
+    <text x="233" y="175" class="small">HpoDisease</text>
+    <text x="233" y="197" class="small">HpoPhenotype</text>
+    <text x="233" y="229" class="small">없음 · 중복 · 형식 오류?</text>
 
-    <rect x="413" y="78" width="166" height="175" rx="15" fill="#0f2c59"/>
-    <text x="433" y="108" class="eyebrow" style="fill:#c8d6e8">03 · LINK</text>
-    <text x="433" y="138" class="head" style="fill:#fff">관계 생성</text>
-    <text x="433" y="176" class="small" style="fill:#dce6f2">HAS_PHENOTYPIC</text>
-    <text x="433" y="198" class="small" style="fill:#dce6f2">_FEATURE</text>
-    <text x="433" y="229" class="small" style="fill:#dce6f2">주석 단위 보존?</text>
+    <rect x="403" y="78" width="154" height="175" rx="15" fill="#0f2c59"/>
+    <text x="423" y="108" class="eyebrow" style="fill:#c8d6e8">03 · LINK</text>
+    <text x="423" y="138" class="head" style="fill:#fff">관계 생성</text>
+    <text x="423" y="176" class="small" style="fill:#dce6f2">HAS_PHENOTYPIC</text>
+    <text x="423" y="198" class="small" style="fill:#dce6f2">_FEATURE</text>
+    <text x="423" y="229" class="small" style="fill:#dce6f2">주석 단위 보존?</text>
 
-    <rect class="box" x="602" y="78" width="166" height="175" rx="15"/>
-    <text x="622" y="108" class="eyebrow">04 · ENRICH</text>
-    <text x="622" y="138" class="head">사람이 읽게</text>
-    <text x="622" y="175" class="small">IEA / PCS / TAS 설명</text>
-    <text x="622" y="197" class="small">createdBy · date</text>
-    <text x="622" y="229" class="small">PubMed / OMIM URL</text>
+    <rect class="box" x="593" y="78" width="154" height="175" rx="15"/>
+    <text x="610" y="108" class="eyebrow">04 · ENRICH</text>
+    <text x="610" y="138" class="head">사람이 읽게</text>
+    <text x="610" y="175" class="small">IEA / PCS / TAS 설명</text>
+    <text x="610" y="197" class="small">createdBy · date</text>
+    <text x="610" y="229" class="small">PubMed / OMIM URL</text>
 
-    <rect class="box" x="791" y="78" width="134" height="175" rx="15"/>
-    <text x="811" y="108" class="eyebrow">05 · CHECK</text>
-    <text x="811" y="138" class="head">품질 게이트</text>
-    <text x="811" y="175" class="small">출처 있음?</text>
-    <text x="811" y="197" class="small">날짜 파싱?</text>
-    <text x="811" y="219" class="small">건수 보존?</text>
+    <rect class="box" x="783" y="78" width="154" height="175" rx="15"/>
+    <text x="803" y="108" class="eyebrow">05 · CHECK</text>
+    <text x="803" y="138" class="head">품질 게이트</text>
+    <text x="803" y="175" class="small">출처 있음?</text>
+    <text x="803" y="197" class="small">날짜 파싱?</text>
+    <text x="803" y="219" class="small">건수 보존?</text>
   </g>
-  <path class="line" d="M201 165H224"/><path class="line" d="M390 165H413"/><path class="line" d="M579 165H602"/><path class="line" d="M768 165H791"/>
+  <path class="line" d="M177 165H213"/><path class="line" d="M367 165H403"/><path class="line" d="M557 165H593"/><path class="line" d="M747 165H783"/>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/build-pipeline.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/build-pipeline.svg
@@ -2,7 +2,7 @@
   <title id="title">임상 질문에서 HPO 기반 지식 그래프와 검증된 질의까지 이어지는 구축 파이프라인</title>
   <desc id="desc">비즈니스 질문, 두 데이터 원천 이해, 기술 선택, 제약과 온톨로지 적재, 주석 병합과 관계 풍부화, 정제, 직접 질의와 계층 추론의 일곱 단계가 이어지며 각 전환에 검증 게이트가 있다.</desc>
   <defs>
-    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.3px;fill:#52647d}
@@ -33,7 +33,7 @@
     <path class="line" d="M578 122H716"/>
   </g>
 
-  <path class="line" d="M814 168V196H766V222"/>
+  <path class="line" d="M814 168V196H936V270H912"/>
 
   <g>
     <rect class="navy" x="620" y="222" width="292" height="96" rx="14"/>
@@ -52,7 +52,7 @@
     <path class="line" d="M334 270H286"/>
   </g>
 
-  <path class="line" d="M167 318V375"/>
+  <path class="line" d="M167 318V344H24V416.5H164"/>
   <rect class="navy" x="164" y="375" width="632" height="83" rx="16"/>
   <text x="480" y="407" class="eyebrow" text-anchor="middle" style="fill:#c8d6e8">07 · USE</text>
   <text x="480" y="435" class="head" text-anchor="middle" style="fill:#fff">직접 연결 질의 + 표현형 조합 랭킹 + subClassOf 계층 추론</text>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/clinical-query.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/clinical-query.svg
@@ -17,6 +17,7 @@
   </defs>
   <rect width="960" height="405" rx="20" fill="#f7f8fa"/>
   <text x="53" y="44" class="eyebrow">OBSERVED PHENOTYPIC FEATURES</text>
+  <text x="480" y="44" class="small" text-anchor="middle">선 = 공유 주석 존재 · 방향 미표현</text>
   <text x="912" y="44" class="eyebrow" text-anchor="end">CANDIDATE DISEASES · OVERLAP COUNT</text>
 
   <g>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/edge-metadata-options.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/edge-metadata-options.svg
@@ -2,8 +2,8 @@
   <title id="title">질병과 표현형 사이 주석 메타데이터를 표현하는 네 가지 방법</title>
   <desc id="desc">RDF n항 관계는 주석 노드를 추가하고, 명명 그래프는 문장 묶음에 이름을 붙이며, RDF-star는 인용한 트리플에 메타데이터를 붙이고, LPG는 개별 관계에 속성을 직접 둔다.</desc>
   <defs>
-    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#0f2c59"/></marker>
-    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#fff"/></marker>
+    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#0f2c59"/></marker>
+    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#fff"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.3px;fill:#52647d}
@@ -13,7 +13,7 @@
       .card{fill:#fff;stroke:#b8c3d2;stroke-width:2}
       .node{fill:#e7eef7;stroke:#0f2c59;stroke-width:2}
       .edge{fill:none;stroke:#0f2c59;stroke-width:3;marker-end:url(#arrow-navy)}
-      .white-edge{fill:none;stroke:#fff;stroke-width:5;marker-end:url(#arrow-white)}
+      .white-edge{fill:none;stroke:#fff;stroke-width:4;marker-end:url(#arrow-white)}
       .edge-label{paint-order:stroke;stroke:#fff;stroke-width:4px;stroke-linejoin:round}
       .meta{fill:#0f2c59}
     </style>
@@ -33,14 +33,14 @@
   <g transform="translate(500 68)">
     <rect class="card" width="425" height="150" rx="16"/>
     <text x="22" y="32" class="eyebrow">RDF</text><text x="22" y="61" class="head">NAMED GRAPH</text>
-    <rect x="49" y="79" width="240" height="63" rx="12" fill="#e7eef7" stroke="#0f2c59" stroke-width="2"/>
+    <rect x="49" y="79" width="220" height="63" rx="12" fill="#e7eef7" stroke="#0f2c59" stroke-width="2"/>
     <circle class="node" cx="93" cy="110" r="22"/><circle class="node" cx="245" cy="110" r="22"/>
     <path class="edge" d="M115 110H223"/>
     <text x="169" y="103" class="small edge-label" text-anchor="middle">hasFeature</text>
-    <rect class="meta" x="315" y="79" width="86" height="63" rx="12"/>
-    <text x="358" y="105" class="small" text-anchor="middle" style="fill:#fff">Graph1</text>
-    <text x="358" y="126" class="small" text-anchor="middle" style="fill:#fff">metadata</text>
-    <path class="edge" d="M315 110H289"/>
+    <rect class="meta" x="319" y="79" width="82" height="63" rx="12"/>
+    <text x="360" y="105" class="small" text-anchor="middle" style="fill:#fff">Graph1</text>
+    <text x="360" y="126" class="small" text-anchor="middle" style="fill:#fff">metadata</text>
+    <path class="edge" d="M319 110H269"/>
   </g>
 
   <g transform="translate(35 245)">
@@ -49,10 +49,10 @@
     <rect x="48" y="83" width="223" height="56" rx="12" fill="#e7eef7" stroke="#0f2c59" stroke-width="2"/>
     <text x="159" y="107" class="label" text-anchor="middle">&lt;&lt; D hasFeature F &gt;&gt;</text>
     <text x="159" y="128" class="small" text-anchor="middle">인용된 트리플</text>
-    <path class="edge" d="M271 111H307"/>
-    <rect class="meta" x="307" y="83" width="89" height="56" rx="12"/>
-    <text x="351" y="106" class="small" text-anchor="middle" style="fill:#fff">source</text>
-    <text x="351" y="126" class="small" text-anchor="middle" style="fill:#fff">date</text>
+    <path class="edge" d="M271 111H315"/>
+    <rect class="meta" x="315" y="83" width="81" height="56" rx="12"/>
+    <text x="355" y="106" class="small" text-anchor="middle" style="fill:#fff">source</text>
+    <text x="355" y="126" class="small" text-anchor="middle" style="fill:#fff">date</text>
   </g>
 
   <g transform="translate(500 245)">

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/hierarchical-inference.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/hierarchical-inference.svg
@@ -2,8 +2,8 @@
   <title id="title">온톨로지 계층이 직접 연결을 상위 범주 질의 결과로 확장하는 과정</title>
   <desc id="desc">HPO의 자식 표현형 세 개가 SUBCLASSOF 관계로 내분비계 이상 상위 개념을 가리킨다. 질병은 하위 표현형에 직접 주석되어 있고 상위 범주 질의에서는 계층 경로를 역방향으로 탐색해 포함된다.</desc>
   <defs>
-    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
-    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#0f2c59"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
+    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#0f2c59"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#52647d}
@@ -25,7 +25,7 @@
   <text x="457" y="108" class="head" text-anchor="middle" style="fill:#fff">endocrine system</text>
   <text x="457" y="133" class="small" text-anchor="middle" style="fill:#dce6f2">HP:0000818 · 상위 범주</text>
 
-  <text x="457" y="166" class="small" text-anchor="middle">SUBCLASSOF · child → parent</text>
+  <text x="720" y="176" class="small" text-anchor="middle">SUBCLASSOF · child → parent</text>
   <path class="tree" d="M194 220V184H420V148"/><path class="tree" d="M457 220V148"/><path class="tree" d="M720 220V184H494V148"/>
   <rect class="node" x="68" y="220" width="252" height="69" rx="14"/>
   <text x="194" y="245" class="head" text-anchor="middle">Abnormality of thyroid</text><text x="194" y="265" class="head" text-anchor="middle">physiology</text><text x="194" y="283" class="small" text-anchor="middle">HP:0002926 · 2 levels</text>
@@ -40,6 +40,6 @@
 
   <rect class="disease" x="652" y="351" width="236" height="69" rx="15"/>
   <text x="770" y="380" class="head" text-anchor="middle">상위 범주 질의</text><text x="770" y="403" class="small" text-anchor="middle">Disease A 포함</text>
-  <path class="infer" d="M346 385C485 385 546 385 644 385"/>
+  <path class="infer" d="M346 385C485 385 554 385 652 385"/>
   <text x="496" y="371" class="small" text-anchor="middle">계층 경로로 암시적 포함</text>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/semantic-bridge.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/semantic-bridge.svg
@@ -2,7 +2,7 @@
   <title id="title">서로 다른 임상 표현을 온톨로지의 표준 개념으로 연결하는 의미 다리</title>
   <desc id="desc">왼쪽의 동의어, 중의적 약어, 서로 다른 세분성이 매핑을 거쳐 가운데 HPO 표준 식별자와 계층으로 정렬되고 오른쪽의 통합 질의로 이어진다.</desc>
   <defs>
-    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#617089"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#617089"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:15px;font-weight:800;letter-spacing:1.5px;fill:#49607d}

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/two-sources-one-graph.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/two-sources-one-graph.svg
@@ -2,8 +2,8 @@
   <title id="title">HPO 온톨로지와 주석 데이터를 하나의 지식 그래프로 결합하는 구조</title>
   <desc id="desc">hp.owl은 표현형 정의와 계층을, phenotype.hpoa는 질병과 표현형의 연관 및 증거를 제공하고, 두 원천이 질병 노드, 표현형 노드, 속성 있는 관계로 결합된다.</desc>
   <defs>
-    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#66758c"/></marker>
-    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#fff"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#66758c"/></marker>
+    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#fff"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.4px;fill:#56677f}
@@ -25,7 +25,8 @@
   <text x="70" y="270" class="eyebrow">SOURCE B · TSV</text>
   <text x="70" y="304" class="head">phenotype.hpoa</text>
   <text x="70" y="337" class="label">질병–표현형 주석</text>
-  <text x="70" y="363" class="small">reference · evidence · frequency · curator</text>
+  <text x="70" y="356" class="small">reference · evidence</text>
+  <text x="70" y="375" class="small">frequency · curator</text>
 
   <path class="line" d="M315 130C374 130 388 174 441 174"/>
   <path class="line" d="M315 310C374 310 388 266 441 266"/>
@@ -33,13 +34,13 @@
 
   <rect x="441" y="70" width="474" height="300" rx="20" fill="#0f2c59"/>
   <text x="678" y="107" class="eyebrow" text-anchor="middle" style="fill:#c9d7e9">ONTOLOGY-GROUNDED LPG</text>
-  <circle cx="545" cy="216" r="54" fill="#fff"/>
+  <circle cx="545" cy="216" r="64" fill="#fff"/>
   <text x="545" y="210" class="label" text-anchor="middle">HpoDisease</text>
   <text x="545" y="235" class="small" text-anchor="middle">OMIM:222100</text>
-  <circle cx="815" cy="216" r="54" fill="#dfe9f6"/>
+  <circle cx="815" cy="216" r="64" fill="#dfe9f6"/>
   <text x="815" y="210" class="label" text-anchor="middle">HpoPhenotype</text>
   <text x="815" y="235" class="small" text-anchor="middle">HP:0410050</text>
-  <path d="M599 216H761" stroke="#fff" stroke-width="5" marker-end="url(#arrow-white)"/>
+  <path d="M609 216H751" fill="none" stroke="#fff" stroke-width="4" marker-end="url(#arrow-white)"/>
   <rect x="602" y="126" width="156" height="61" rx="10" fill="#fff"/>
   <text x="680" y="151" class="small" text-anchor="middle">HAS_PHENOTYPIC</text>
   <text x="680" y="171" class="small" text-anchor="middle">_FEATURE</text>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/validation-gates.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/validation-gates.svg
@@ -2,13 +2,14 @@
   <title id="title">온톨로지 기반 임상 지원 지식 그래프의 네 검증 게이트</title>
   <desc id="desc">원천 스냅샷, 의미 매핑, 적재 보존성, 질의와 추론의 임상 경계를 각각 검증한 뒤 후보 결과를 사람에게 전달하며 실패하면 이전 단계로 되돌아간다.</desc>
   <defs>
-    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#63728a"/></marker>
-    <marker id="arrow-red" markerUnits="userSpaceOnUse" viewBox="0 0 8 6" refX="7.5" refY="3" markerWidth="8" markerHeight="6" orient="auto"><path d="M.5.5 7.5 3 .5 5.5Z" fill="#a15b55"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
+    <marker id="arrow-red" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#a15b55"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#52647d}
       .head{font-size:18px;font-weight:800}
       .small{font-size:13px;fill:#56657a}
+      .gate-note{font-size:12px;letter-spacing:.6px}
       .gate{fill:#fff;stroke:#b7c2d1;stroke-width:2}
       .line{fill:none;stroke:#63728a;stroke-width:3;marker-end:url(#arrow-gray)}
       .return{fill:none;stroke:#a15b55;stroke-width:2.5;stroke-dasharray:7 5;marker-end:url(#arrow-red)}
@@ -23,7 +24,7 @@
     <text x="66" y="174" class="small">버전·다운로드 시점</text>
     <text x="66" y="199" class="small">컬럼·결측·식별자</text>
     <text x="66" y="224" class="small">라이선스·출처</text>
-    <text x="66" y="263" class="eyebrow">FAIL → SNAPSHOT FIX</text>
+    <text x="142" y="263" class="eyebrow gate-note" text-anchor="middle">FAIL → SNAPSHOT FIX</text>
 
     <rect class="gate" x="270" y="91" width="196" height="205" rx="16"/>
     <circle cx="310" cy="128" r="19" fill="#0f2c59"/><text x="310" y="134" class="small" text-anchor="middle" style="fill:#fff">2</text>
@@ -31,7 +32,7 @@
     <text x="292" y="174" class="small">질병 vs 표현형 역할</text>
     <text x="292" y="199" class="small">HPO ID 매핑</text>
     <text x="292" y="224" class="small">계층 방향·동의어</text>
-    <text x="292" y="263" class="eyebrow">FAIL → MAPPING REVIEW</text>
+    <text x="368" y="263" class="eyebrow gate-note" text-anchor="middle">FAIL → MAPPING REVIEW</text>
 
     <rect class="gate" x="496" y="91" width="196" height="205" rx="16"/>
     <circle cx="536" cy="128" r="19" fill="#0f2c59"/><text x="536" y="134" class="small" text-anchor="middle" style="fill:#fff">3</text>
@@ -39,7 +40,7 @@
     <text x="518" y="174" class="small">노드·관계 건수</text>
     <text x="518" y="199" class="small">주석 중복 보존</text>
     <text x="518" y="224" class="small">근거 속성 파싱</text>
-    <text x="518" y="263" class="eyebrow">FAIL → MODEL / ETL FIX</text>
+    <text x="594" y="263" class="eyebrow gate-note" text-anchor="middle">FAIL → MODEL / ETL FIX</text>
 
     <rect x="722" y="91" width="196" height="205" rx="16" fill="#0f2c59"/>
     <circle cx="762" cy="128" r="19" fill="#fff"/><text x="762" y="134" class="small" text-anchor="middle">4</text>
@@ -47,10 +48,10 @@
     <text x="744" y="174" class="small" style="fill:#dce6f2">대표 질의 재현</text>
     <text x="744" y="199" class="small" style="fill:#dce6f2">추론 범위·깊이</text>
     <text x="744" y="224" class="small" style="fill:#dce6f2">후보와 진단 분리</text>
-    <text x="820" y="263" class="eyebrow" text-anchor="middle" style="fill:#c8d6e8">PASS → HUMAN REVIEW</text>
+    <text x="820" y="263" class="eyebrow gate-note" text-anchor="middle" style="fill:#c8d6e8">PASS → HUMAN REVIEW</text>
   </g>
   <path class="line" d="M240 193H270"/><path class="line" d="M466 193H496"/><path class="line" d="M692 193H722"/>
-  <path class="return" d="M820 296C820 370 580 380 580 296"/>
-  <path class="return" d="M580 296C580 408 357 408 357 296"/>
-  <path class="return" d="M357 296C357 370 143 370 143 296"/>
+  <path class="return" d="M820 296C820 366 570 366 570 296"/>
+  <path class="return" d="M618 296C618 408 344 408 344 296"/>
+  <path class="return" d="M392 296C392 366 142 366 142 296"/>
 </svg>


### PR DESCRIPTION
## Summary
- audit all 8 Chapter 3 SVGs and all 34 directional arrow paths
- route Figure 4 loop arrows to the correct box side centers
- standardize visible arrowheads and restore clear shafts for short connectors
- separate validation return anchors and clarify intentionally undirected clinical-query lines
- resolve label overflow and align repeated diagram elements consistently

## Validation
- `xmllint --noout` for all 8 SVGs
- `python3 agent-support/scripts/build-index.py --check`
- `python3 agent-support/scripts/validate-site.py --check-materials`
- all 27 slides at 1280×720, 1366×768, and 390×844 with no clipping or overflow
- report at desktop/mobile widths; all 8 images loaded and lightbox verified
- Claude browser/DOM review: PASS; 34/34 arrow endpoints on intended boundaries, no head-only arrows