### PR TITLE
Enlarge Chapter 3 arrowheads

### DIFF
--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/annotation-lifecycle.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/annotation-lifecycle.svg
@@ -2,7 +2,7 @@
   <title id="title">HPOA 한 행이 추적 가능한 그래프 관계가 되는 생애주기</title>
   <desc id="desc">TSV 한 행에서 질병과 표현형 ID를 매칭하고 관계를 생성한 뒤 원시 근거 필드를 추가하고 사람이 읽는 설명과 URL로 풍부화하며 품질 점검을 거친다.</desc>
   <defs>
-    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#63728a"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#53647d}

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/build-pipeline.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/build-pipeline.svg
@@ -2,7 +2,7 @@
   <title id="title">임상 질문에서 HPO 기반 지식 그래프와 검증된 질의까지 이어지는 구축 파이프라인</title>
   <desc id="desc">비즈니스 질문, 두 데이터 원천 이해, 기술 선택, 제약과 온톨로지 적재, 주석 병합과 관계 풍부화, 정제, 직접 질의와 계층 추론의 일곱 단계가 이어지며 각 전환에 검증 게이트가 있다.</desc>
   <defs>
-    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#63728a"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.3px;fill:#52647d}
@@ -52,8 +52,8 @@
     <path class="line" d="M334 270H286"/>
   </g>
 
-  <path class="line" d="M167 318V344H24V416.5H164"/>
-  <rect class="navy" x="164" y="375" width="632" height="83" rx="16"/>
+  <path class="line" d="M167 318V375"/>
+  <rect class="navy" x="48" y="375" width="864" height="83" rx="16"/>
   <text x="480" y="407" class="eyebrow" text-anchor="middle" style="fill:#c8d6e8">07 · USE</text>
   <text x="480" y="435" class="head" text-anchor="middle" style="fill:#fff">직접 연결 질의 + 표현형 조합 랭킹 + subClassOf 계층 추론</text>
 </svg>

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/edge-metadata-options.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/edge-metadata-options.svg
@@ -2,8 +2,8 @@
   <title id="title">질병과 표현형 사이 주석 메타데이터를 표현하는 네 가지 방법</title>
   <desc id="desc">RDF n항 관계는 주석 노드를 추가하고, 명명 그래프는 문장 묶음에 이름을 붙이며, RDF-star는 인용한 트리플에 메타데이터를 붙이고, LPG는 개별 관계에 속성을 직접 둔다.</desc>
   <defs>
-    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#0f2c59"/></marker>
-    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#fff"/></marker>
+    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#0f2c59"/></marker>
+    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#fff"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.3px;fill:#52647d}

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/hierarchical-inference.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/hierarchical-inference.svg
@@ -2,8 +2,8 @@
   <title id="title">온톨로지 계층이 직접 연결을 상위 범주 질의 결과로 확장하는 과정</title>
   <desc id="desc">HPO의 자식 표현형 세 개가 SUBCLASSOF 관계로 내분비계 이상 상위 개념을 가리킨다. 질병은 하위 표현형에 직접 주석되어 있고 상위 범주 질의에서는 계층 경로를 역방향으로 탐색해 포함된다.</desc>
   <defs>
-    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
-    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#0f2c59"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#63728a"/></marker>
+    <marker id="arrow-navy" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#0f2c59"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#52647d}

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/semantic-bridge.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/semantic-bridge.svg
@@ -2,7 +2,7 @@
   <title id="title">서로 다른 임상 표현을 온톨로지의 표준 개념으로 연결하는 의미 다리</title>
   <desc id="desc">왼쪽의 동의어, 중의적 약어, 서로 다른 세분성이 매핑을 거쳐 가운데 HPO 표준 식별자와 계층으로 정렬되고 오른쪽의 통합 질의로 이어진다.</desc>
   <defs>
-    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#617089"/></marker>
+    <marker id="arrow" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#617089"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:15px;font-weight:800;letter-spacing:1.5px;fill:#49607d}

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/two-sources-one-graph.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/two-sources-one-graph.svg
@@ -2,8 +2,8 @@
   <title id="title">HPO 온톨로지와 주석 데이터를 하나의 지식 그래프로 결합하는 구조</title>
   <desc id="desc">hp.owl은 표현형 정의와 계층을, phenotype.hpoa는 질병과 표현형의 연관 및 증거를 제공하고, 두 원천이 질병 노드, 표현형 노드, 속성 있는 관계로 결합된다.</desc>
   <defs>
-    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#66758c"/></marker>
-    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#fff"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#66758c"/></marker>
+    <marker id="arrow-white" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#fff"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:14px;font-weight:800;letter-spacing:1.4px;fill:#56677f}

--- a/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/validation-gates.svg
+++ b/docs/studies/knowledge-graphs-and-llms-in-action/presentations/2026-08-01-ch03/assets/figs/validation-gates.svg
@@ -2,8 +2,8 @@
   <title id="title">온톨로지 기반 임상 지원 지식 그래프의 네 검증 게이트</title>
   <desc id="desc">원천 스냅샷, 의미 매핑, 적재 보존성, 질의와 추론의 임상 경계를 각각 검증한 뒤 후보 결과를 사람에게 전달하며 실패하면 이전 단계로 되돌아간다.</desc>
   <defs>
-    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#63728a"/></marker>
-    <marker id="arrow-red" markerUnits="userSpaceOnUse" viewBox="0 0 12 10" refX="11.5" refY="5" markerWidth="12" markerHeight="10" orient="auto"><path d="M.5.5 11.5 5 .5 9.5Z" fill="#a15b55"/></marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#63728a"/></marker>
+    <marker id="arrow-red" markerUnits="userSpaceOnUse" viewBox="0 0 18 14" refX="17.5" refY="7" markerWidth="18" markerHeight="14" orient="auto"><path d="M.5.5 17.5 7 .5 13.5Z" fill="#a15b55"/></marker>
     <style>
       text{font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#172033}
       .eyebrow{font-size:13px;font-weight:800;letter-spacing:1.2px;fill:#52647d}


### PR DESCRIPTION
## Summary
- enlarge all directional SVG markers from 12×10 to 18×14 for projector readability
- keep every arrow endpoint anchored to the existing intended boundary
- align Figure 4 step 07 with the full process row and route step 06 straight down to its top edge

## Validation
- `xmllint --noout` for all 8 SVGs
- required index and site validation scripts passed
- all 27 slides passed at 1280×720, 1366×768, and 390×844
- report passed at desktop/mobile widths with all 8 images loaded
- direct 8-image visual contact sheet and Figure 4 slide inspected